### PR TITLE
Fix updater

### DIFF
--- a/bragbook-gallery.php
+++ b/bragbook-gallery.php
@@ -3,7 +3,7 @@
 Plugin Name: BRAG book Gallery
 Plugin URI: https://github.com/bragbook/BRAGbook/releases/latest
 Description: Installs necessary components to allow for easy implementation of the BRAG book before and after gallery from Candace Crowe Design.
-Version: 1.7
+Version: 1.7.3
 Author: Candace Crowe Design
 Author URI: https://www.candacecrowe.com/
 License: A "Slug" license name e.g. GPL2

--- a/updater.php
+++ b/updater.php
@@ -2,42 +2,40 @@
 
 class Bragbook_Updater {
 
-	private string $file;
-	private array $plugin = [];
-	private string $basename = '';
-	private bool $active = false;
-	private string $username = 'bragbook';
-	private string $repository = 'BRAGbook';
-	private ?string $authorize_token = null;
-	private array $github_response = [];
+	private $file;
+	private $plugin;
+	private $basename;
+	private $active;
+	private $username;
+	private $repository;
+	private $authorize_token;
+	private $github_response;
 
-	public function __construct(string $file) {
+	public function __construct($file) {
 		$this->file = $file;
 		add_action('admin_init', [$this, 'set_plugin_properties']);
 	}
 
-	public function set_plugin_properties(): void {
-		$this->plugin = get_plugin_data($this->file);
-		$this->basename = plugin_basename($this->file);
-		$this->active = is_plugin_active($this->basename);
+	public function set_plugin_properties() {
+		$this->plugin    = get_plugin_data($this->file);
+		$this->basename  = plugin_basename($this->file);
+		$this->active    = is_plugin_active($this->basename);
 	}
 
-	public function set_username(string $username): void {
+	public function set_username($username) {
 		$this->username = $username;
 	}
 
-	public function set_repository(string $repository): void {
+	public function set_repository($repository) {
 		$this->repository = $repository;
 	}
 
-	public function authorize(string $token): void {
+	public function authorize($token) {
 		$this->authorize_token = $token;
 	}
 
-	private function get_repository_info(): void {
-		if (!empty($this->github_response)) {
-			return;
-		}
+	private function get_repository_info() {
+		if (!empty($this->github_response)) return;
 
 		$request_uri = sprintf('https://api.github.com/repos/%s/%s/releases/latest', $this->username, $this->repository);
 
@@ -52,37 +50,39 @@ class Bragbook_Updater {
 			$args['headers']['Authorization'] = 'token ' . $this->authorize_token;
 		}
 
-		$response = wp_remote_get($request_uri, $args);
+		$response_raw = wp_remote_get($request_uri, $args);
 
-		if (is_wp_error($response)) {
+		if (is_wp_error($response_raw)) {
+			error_log('GitHub Updater Error: ' . $response_raw->get_error_message());
 			return;
 		}
 
-		$data = json_decode(wp_remote_retrieve_body($response), true);
+		$response = json_decode(wp_remote_retrieve_body($response_raw), true);
 
-		if (is_array($data)) {
-			$this->github_response = $data;
+		if (!is_array($response)) {
+			error_log('GitHub Updater Error: Invalid JSON response from GitHub');
+			return;
 		}
+
+		$this->github_response = $response;
 	}
 
-	public function initialize(): void {
+	public function initialize() {
 		add_filter('pre_set_site_transient_update_plugins', [$this, 'modify_transient']);
 		add_filter('plugins_api', [$this, 'plugin_popup'], 10, 3);
 		add_filter('upgrader_post_install', [$this, 'after_install'], 10, 3);
 	}
 
 	public function modify_transient($transient) {
-		if (!property_exists($transient, 'checked')) {
-			return $transient;
-		}
+		if (!property_exists($transient, 'checked')) return $transient;
 
 		$this->get_repository_info();
+		if (empty($this->github_response)) return $transient;
 
-		$checked = $transient->checked;
-		$current_version = $checked[$this->basename] ?? null;
-		$remote_version = $this->github_response['tag_name'] ?? null;
+		$current_version = $transient->checked[$this->basename] ?? null;
+		$remote_version = ltrim($this->github_response['tag_name'] ?? '', 'v');
 
-		if ($current_version && $remote_version && version_compare($remote_version, $current_version, '>')) {
+		if ($current_version && version_compare($remote_version, $current_version, '>')) {
 			$slug = current(explode('/', $this->basename));
 			$plugin = [
 				'url'         => $this->plugin['PluginURI'] ?? '',
@@ -97,40 +97,44 @@ class Bragbook_Updater {
 	}
 
 	public function plugin_popup($result, $action, $args) {
-		if ($action !== 'plugin_information' || empty($args->slug)) {
-			return $result;
-		}
+		if ($action !== 'plugin_information' || empty($args->slug)) return $result;
+		if ($args->slug !== current(explode('/', $this->basename))) return $result;
 
-		if ($args->slug === current(explode('/', $this->basename))) {
-			$this->get_repository_info();
+		$this->get_repository_info();
+		if (empty($this->github_response)) return $result;
 
-			$plugin = [
-				'name'              => $this->plugin['Name'] ?? 'BRAGbook',
-				'slug'              => $this->basename,
-				'version'           => $this->github_response['tag_name'] ?? '',
-				'author'            => $this->plugin['AuthorName'] ?? '',
-				'author_profile'    => $this->plugin['AuthorURI'] ?? '',
-				'last_updated'      => $this->github_response['published_at'] ?? '',
-				'homepage'          => $this->plugin['PluginURI'] ?? '',
-				'short_description' => $this->plugin['Description'] ?? '',
-				'sections'          => [
-					'Description' => $this->plugin['Description'] ?? '',
-					'Updates'     => $this->github_response['body'] ?? '',
-				],
-				'download_link'     => $this->github_response['zipball_url'] ?? '',
-			];
+		$plugin = [
+			'name'              => $this->plugin['Name'] ?? 'BRAGbook',
+			'slug'              => $this->basename,
+			'version'           => ltrim($this->github_response['tag_name'], 'v'),
+			'author'            => $this->plugin['AuthorName'] ?? '',
+			'author_profile'    => $this->plugin['AuthorURI'] ?? '',
+			'last_updated'      => $this->github_response['published_at'] ?? '',
+			'homepage'          => $this->plugin['PluginURI'] ?? '',
+			'short_description' => $this->plugin['Description'] ?? '',
+			'sections' => [
+				'Description' => $this->plugin['Description'] ?? '',
+				'Updates'     => $this->github_response['body'] ?? '',
+			],
+			'download_link' => $this->github_response['zipball_url'] ?? '',
+		];
 
-			return (object) $plugin;
-		}
-
-		return $result;
+		return (object) $plugin;
 	}
 
 	public function after_install($response, $hook_extra, $result) {
 		global $wp_filesystem;
 
 		$install_directory = plugin_dir_path($this->file);
-		$wp_filesystem->move($result['destination'], $install_directory);
+
+		// Delete old files first to avoid merge conflict from GitHub archive structure
+		$wp_filesystem->delete($install_directory, true);
+
+		if (! $wp_filesystem->move($result['destination'], $install_directory)) {
+			error_log('GitHub Updater Error: Failed to move plugin to install directory.');
+			return $result;
+		}
+
 		$result['destination'] = $install_directory;
 
 		if ($this->active) {

--- a/updater.php
+++ b/updater.php
@@ -2,156 +2,139 @@
 
 class Bragbook_Updater {
 
-	private $file;
+	private string $file;
+	private array $plugin = [];
+	private string $basename = '';
+	private bool $active = false;
+	private string $username = 'bragbook';
+	private string $repository = 'BRAGbook';
+	private ?string $authorize_token = null;
+	private array $github_response = [];
 
-	private $plugin;
-
-	private $basename;
-
-	private $active;
-
-	private $username;
-
-	private $repository;
-
-	private $authorize_token;
-
-	private $github_response;
-
-	public function __construct( $file ) {
-
+	public function __construct(string $file) {
 		$this->file = $file;
-
-		add_action( 'admin_init', array( $this, 'set_plugin_properties' ) );
-
-		return $this;
+		add_action('admin_init', [$this, 'set_plugin_properties']);
 	}
 
-	public function set_plugin_properties() {
-		$this->plugin	= get_plugin_data( $this->file );
-		$this->basename = plugin_basename( $this->file );
-		$this->active	= is_plugin_active( $this->basename );
+	public function set_plugin_properties(): void {
+		$this->plugin = get_plugin_data($this->file);
+		$this->basename = plugin_basename($this->file);
+		$this->active = is_plugin_active($this->basename);
 	}
 
-	public function set_username( $username ) {
+	public function set_username(string $username): void {
 		$this->username = $username;
 	}
 
-	public function set_repository( $repository ) {
+	public function set_repository(string $repository): void {
 		$this->repository = $repository;
 	}
 
-	public function authorize( $token ) {
+	public function authorize(string $token): void {
 		$this->authorize_token = $token;
 	}
 
-	private function get_repository_info() {
-	    if ( is_null( $this->github_response ) ) { // Do we have a response?
-	        $request_uri = sprintf( 'https://api.github.com/repos/%s/%s/releases', $this->username, $this->repository ); // Build URI
+	private function get_repository_info(): void {
+		if (!empty($this->github_response)) {
+			return;
+		}
 
-	        if( $this->authorize_token ) { // Is there an access token?
-	            $request_uri = add_query_arg( 'access_token', $this->authorize_token, $request_uri ); // Append it
-	        }
+		$request_uri = sprintf('https://api.github.com/repos/%s/%s/releases/latest', $this->username, $this->repository);
 
-	        $response = json_decode( wp_remote_retrieve_body( wp_remote_get( $request_uri ) ), true ); // Get JSON and parse it
+		$args = [
+			'headers' => [
+				'Accept' => 'application/vnd.github.v3+json',
+				'User-Agent' => 'WordPress/' . get_bloginfo('version'),
+			]
+		];
 
-	        if( is_array( $response ) ) { // If it is an array
-	            $response = current( $response ); // Get the first item
-	        }
+		if ($this->authorize_token) {
+			$args['headers']['Authorization'] = 'token ' . $this->authorize_token;
+		}
 
-	        if( $this->authorize_token ) { // Is there an access token?
-	            $response['zipball_url'] = add_query_arg( 'access_token', $this->authorize_token, $response['zipball_url'] ); // Update our zip url with token
-	        }
+		$response = wp_remote_get($request_uri, $args);
 
-	        $this->github_response = $response; // Set it to our property
-	    }
+		if (is_wp_error($response)) {
+			return;
+		}
+
+		$data = json_decode(wp_remote_retrieve_body($response), true);
+
+		if (is_array($data)) {
+			$this->github_response = $data;
+		}
 	}
 
-	public function initialize() {
-		add_filter( 'pre_set_site_transient_update_plugins', array( $this, 'modify_transient' ), 10, 1 );
-		add_filter( 'plugins_api', array( $this, 'plugin_popup' ), 10, 3);
-		add_filter( 'upgrader_post_install', array( $this, 'after_install' ), 10, 3 );
+	public function initialize(): void {
+		add_filter('pre_set_site_transient_update_plugins', [$this, 'modify_transient']);
+		add_filter('plugins_api', [$this, 'plugin_popup'], 10, 3);
+		add_filter('upgrader_post_install', [$this, 'after_install'], 10, 3);
 	}
 
-public function modify_transient( $transient ) {
+	public function modify_transient($transient) {
+		if (!property_exists($transient, 'checked')) {
+			return $transient;
+		}
 
-	if ( property_exists( $transient, 'checked' ) ) {
+		$this->get_repository_info();
 
-		if ( $checked = $transient->checked ) {
+		$checked = $transient->checked;
+		$current_version = $checked[$this->basename] ?? null;
+		$remote_version = $this->github_response['tag_name'] ?? null;
+
+		if ($current_version && $remote_version && version_compare($remote_version, $current_version, '>')) {
+			$slug = current(explode('/', $this->basename));
+			$plugin = [
+				'url'         => $this->plugin['PluginURI'] ?? '',
+				'slug'        => $slug,
+				'package'     => $this->github_response['zipball_url'],
+				'new_version' => $remote_version,
+			];
+			$transient->response[$this->basename] = (object) $plugin;
+		}
+
+		return $transient;
+	}
+
+	public function plugin_popup($result, $action, $args) {
+		if ($action !== 'plugin_information' || empty($args->slug)) {
+			return $result;
+		}
+
+		if ($args->slug === current(explode('/', $this->basename))) {
 			$this->get_repository_info();
 
-			if (
-				is_array( $checked ) &&
-				isset( $checked[ $this->basename ] ) &&
-				is_string( $checked[ $this->basename ] ) &&
-				isset( $this->github_response['tag_name'] ) &&
-				is_string( $this->github_response['tag_name'] )
-			) {
-				$out_of_date = version_compare( $this->github_response['tag_name'], $checked[ $this->basename ], 'gt' );
-			} else {
-				$out_of_date = false;
-			}
+			$plugin = [
+				'name'              => $this->plugin['Name'] ?? 'BRAGbook',
+				'slug'              => $this->basename,
+				'version'           => $this->github_response['tag_name'] ?? '',
+				'author'            => $this->plugin['AuthorName'] ?? '',
+				'author_profile'    => $this->plugin['AuthorURI'] ?? '',
+				'last_updated'      => $this->github_response['published_at'] ?? '',
+				'homepage'          => $this->plugin['PluginURI'] ?? '',
+				'short_description' => $this->plugin['Description'] ?? '',
+				'sections'          => [
+					'Description' => $this->plugin['Description'] ?? '',
+					'Updates'     => $this->github_response['body'] ?? '',
+				],
+				'download_link'     => $this->github_response['zipball_url'] ?? '',
+			];
 
-			if ( $out_of_date ) {
-				$new_files = $this->github_response['zipball_url'];
-				$slug = current( explode( '/', $this->basename ) );
-
-				$plugin = array(
-					'url'         => $this->plugin["PluginURI"],
-					'slug'        => $slug,
-					'package'     => $new_files,
-					'new_version' => $this->github_response['tag_name']
-				);
-
-				$transient->response[ $this->basename ] = (object) $plugin;
-			}
+			return (object) $plugin;
 		}
+
+		return $result;
 	}
 
-	return $transient;
-}
-	
-	public function plugin_popup( $result, $action, $args ) {
+	public function after_install($response, $hook_extra, $result) {
+		global $wp_filesystem;
 
-		if( ! empty( $args->slug ) ) { // If there is a slug
-			
-			if( $args->slug == current( explode( '/' , $this->basename ) ) ) { // And it's our slug
+		$install_directory = plugin_dir_path($this->file);
+		$wp_filesystem->move($result['destination'], $install_directory);
+		$result['destination'] = $install_directory;
 
-				$this->get_repository_info(); // Get our repo info
-
-				// Set it to an array
-				$plugin = array(
-					'name'				=> $this->plugin["Name"],
-					'slug'				=> $this->basename,
-					'version'			=> $this->github_response['tag_name'],
-					'author'			=> $this->plugin["AuthorName"],
-					'author_profile'	=> $this->plugin["AuthorURI"],
-					'last_updated'		=> $this->github_response['published_at'],
-					'homepage'			=> $this->plugin["PluginURI"],
-					'short_description' => $this->plugin["Description"],
-					'sections'			=> array(
-						'Description'	=> $this->plugin["Description"],
-						'Updates'		=> $this->github_response['body'],
-					),
-					'download_link'		=> $this->github_response['zipball_url']
-				);
-
-				return (object) $plugin; // Return the data
-			}
-
-		}
-		return $result; // Otherwise return default
-	}
-
-	public function after_install( $response, $hook_extra, $result ) {
-		global $wp_filesystem; // Get global FS object
-
-		$install_directory = plugin_dir_path( $this->file ); // Our plugin directory
-		$wp_filesystem->move( $result['destination'], $install_directory ); // Move files to the plugin dir
-		$result['destination'] = $install_directory; // Set the destination for the rest of the stack
-
-		if ( $this->active ) { // If it was active
-			activate_plugin( $this->basename ); // Reactivate
+		if ($this->active) {
+			activate_plugin($this->basename);
 		}
 
 		return $result;


### PR DESCRIPTION
Revised update method based on 1.6 updater
- Modernized all syntax: replaced legacy array() with [] and improved code readability.
- Replaced deprecated GitHub API token query param with secure Authorization header.
- Switched GitHub release fetch to releases/latest endpoint for cleaner versioning.
- Added error handling for failed plugin move after install (after_install() now logs failure).
- Cleaned up redundant conditionals, normalized indentation, and ensured PHP 8 compatibility.